### PR TITLE
Fix SVG overlap with QuickMenuBar and TabBar by adjusting layout

### DIFF
--- a/src/components/CanvasArea.tsx
+++ b/src/components/CanvasArea.tsx
@@ -10,7 +10,7 @@ import { keyActionMap } from '../constants/KeyActionMap';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useElementDragEffect } from '../hooks/useElementDragEffect';
 import { helpContent } from '../constants/HelpContent';
-import { ICONBAR_HEIGHT } from '../constants/ElementSettings';
+import { ICONBAR_HEIGHT, HEADER_HEIGHT } from '../constants/ElementSettings';
 import { Element } from '../types';
 
 interface Toast {
@@ -101,7 +101,12 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ isHelpOpen, toggleHelp }) => {
                 </div>
             ))}
 
-            <div style={{ position: 'absolute', top: 0, left: 0, overflow: 'auto' }}>
+            <div style={{
+                position: 'absolute',
+                top: HEADER_HEIGHT,
+                left: 0,
+                overflow: 'auto'
+            }}>
                 <ModalWindow isOpen={isHelpOpen} onClose={toggleHelp}>
                     <div dangerouslySetInnerHTML={{ __html: helpContent }} />
                 </ModalWindow>

--- a/src/constants/ElementSettings.ts
+++ b/src/constants/ElementSettings.ts
@@ -2,7 +2,7 @@
 export const DEFAULT_ZOOM_RATIO = 1;
 export const DEFAULT_POSITION = {
     X: 50,
-    Y: 100,
+    Y: 50,
 }
 export const SIZE = {
     NODE_HEIGHT: 72,
@@ -43,3 +43,5 @@ export const MULTIBYTE_CHAR_WIDTH = 14;
 export const SINGLEBYTE_CHAR_WIDTH = 7;
 export const LINE_HEIGHT_RATIO = 1.4;
 export const ICONBAR_HEIGHT = 40;
+export const TABBAR_HEIGHT = 40;
+export const HEADER_HEIGHT = ICONBAR_HEIGHT + TABBAR_HEIGHT;

--- a/src/context/AppContent.tsx
+++ b/src/context/AppContent.tsx
@@ -8,7 +8,7 @@ import { reducer } from '../state/state';
 import QuickMenuBar from '../components/QuickMenuBar';
 import { saveSvg } from '../utils/FileHelpers';
 import { loadElements, saveElements } from '../utils/FileHelpers';
-import { ICONBAR_HEIGHT } from '../constants/ElementSettings';
+import { ICONBAR_HEIGHT, TABBAR_HEIGHT } from '../constants/ElementSettings';
 import { TabState } from './TabsContext';
 import { getLastSavedFileName } from '../utils/FileHelpers';
 
@@ -70,7 +70,7 @@ const TabHeaders: React.FC<{
     alignItems: 'center',
     backgroundColor: '#f0f0f0',
     width: '100%',
-    height: ICONBAR_HEIGHT,
+    height: TABBAR_HEIGHT,
     marginTop: ICONBAR_HEIGHT,
     position: 'fixed',
     zIndex: 10001,

--- a/src/hooks/useElementDragEffect.tsx
+++ b/src/hooks/useElementDragEffect.tsx
@@ -1,7 +1,7 @@
 // src/hooks/useElementDragEffect.tsx
 import { useState, useEffect, useCallback } from 'react';
 import { useCanvas } from '../context/CanvasContext';
-import { ICONBAR_HEIGHT } from '../constants/ElementSettings';
+import { HEADER_HEIGHT } from '../constants/ElementSettings';
 import { Element } from '../types';
 import { isDescendant } from '../state/state';
 import { ToastMessages } from '../constants/ToastMessages';
@@ -28,7 +28,7 @@ export const useElementDragEffect = ({ showToast }: UseElementDragEffectProps) =
 
   const convertToZoomCoordinates = useCallback((e: { pageX: number; pageY: number }): Position => ({
     x: e.pageX / state.zoomRatio,
-    y: (e.pageY - ICONBAR_HEIGHT) / state.zoomRatio,
+    y: (e.pageY - HEADER_HEIGHT) / state.zoomRatio,
   }), [state.zoomRatio]);
 
   const handleMouseDown = useCallback(

--- a/src/hooks/useResizeEffect.tsx
+++ b/src/hooks/useResizeEffect.tsx
@@ -1,6 +1,7 @@
 // src/hooks/useResizeEffect.tsx
 import { useEffect } from 'react';
 import { calculateCanvasSize } from '../utils/LayoutUtilities';
+import { ICONBAR_HEIGHT } from '../constants/ElementSettings';
 
 interface ElementWithDimensions {
   x: number;
@@ -28,14 +29,15 @@ const useResizeEffect = ({
 }: ResizeEffectProps) => {
     useEffect(() => {
         const newCanvasSize = calculateCanvasSize(state.elements);
+        const maxHeight = window.innerHeight - ICONBAR_HEIGHT * 2;
         newCanvasSize.width = Math.max(newCanvasSize.width, window.innerWidth);
-        newCanvasSize.height = Math.max(newCanvasSize.height, window.innerHeight);
+        newCanvasSize.height = Math.max(newCanvasSize.height, maxHeight);
         const newViewSize = {
             width: newCanvasSize.width,
             height: newCanvasSize.height,
         }
-        newCanvasSize.width = newCanvasSize.width * state.zoomRatio;
-        newCanvasSize.height = newCanvasSize.height * state.zoomRatio;
+        newCanvasSize.width *= state.zoomRatio;
+        newCanvasSize.height *= state.zoomRatio;
         
         setCanvasSize(newCanvasSize);
         setDisplayArea(`0 0 ${newViewSize.width} ${newViewSize.height}`);


### PR DESCRIPTION
Fix SVG overlap with QuickMenuBar and TabBar by adjusting layout calculations

- Adjusted initial element positioning (DEFAULT_POSITION.Y) to account for the height of the QuickMenuBar and TabBar.
- Modified SVG container positioning to ensure content starts below the menu bars.
- Updated resize logic to consider menu bar heights when calculating SVG dimensions.
- Ensured proper scaling of SVG elements relative to the zoom ratio without overlapping UI components.