### PR TITLE
Fix: Confirm and cancel buttons processing

### DIFF
--- a/src/components/ideaElement.tsx
+++ b/src/components/ideaElement.tsx
@@ -90,7 +90,7 @@ const renderActionButtons = (element: CanvasElement, dispatch: React.Dispatch<an
               transition: 'color 0.2s ease-in-out'
             }}
             style={{ width: '100%', height: '100%' }}
-            onClick={() => dispatch({ type: 'CONFIRM_TENTATIVE_ELEMENTS' })}
+            onClick={() => dispatch({ type: 'CONFIRM_TENTATIVE_ELEMENTS', payload: element.parentId })}
           />
         </foreignObject>
       </g>
@@ -115,7 +115,7 @@ const renderActionButtons = (element: CanvasElement, dispatch: React.Dispatch<an
               transition: 'color 0.2s ease-in-out'
             }}
             style={{ width: '100%', height: '100%' }}
-            onClick={() => dispatch({ type: 'CANCEL_TENTATIVE_ELEMENTS' })}
+            onClick={() => dispatch({ type: 'CANCEL_TENTATIVE_ELEMENTS', payload: element.parentId })}
           />
         </foreignObject>
       </g>


### PR DESCRIPTION
Confirm and cancel buttons only process elements with the same parentId